### PR TITLE
[Week02] BOJ: 퇴사2

### DIFF
--- a/weekly/week02/BOJ_15486_퇴사2/sukangpunch.java
+++ b/weekly/week02/BOJ_15486_퇴사2/sukangpunch.java
@@ -1,0 +1,39 @@
+package stduy.week02;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// 퇴사 2
+// 답 확인
+public class BOJ_15486 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        int[] T = new int[N + 1];
+        int[] P = new int[N + 1];
+
+        for(int i = 1; i <= N; i++){
+            String[] s = br.readLine().split(" ");
+            T[i] = Integer.parseInt(s[0]);
+            P[i] = Integer.parseInt(s[1]);
+        }
+
+        int[] dp = new int[N + 2]; // N+1일에 끝나는 상담을 위해 N+2 크기
+
+        for(int i = 1; i <= N; i++){
+            // i 일에 상담을 하지 않으면, i일의 수익이 i+1 에도 그대로 유지
+            dp[i + 1] = Math.max(dp[i + 1], dp[i]);
+
+            // i일에 상담을 하는 경우
+            int endDay = i + T[i];
+            if(endDay <= N + 1){
+                dp[endDay] = Math.max(dp[endDay], dp[i] + P[i]); // 수익이 발생하는 날에 바로 P값을 적용한 결과 저장
+            }
+        }
+
+        System.out.println(dp[N + 1]);
+    }
+}


### PR DESCRIPTION
## 문제 정보

- **플랫폼**: 백준
- **문제 번호**: 15486
- **문제 이름**: 퇴사 2
- **문제 링크**: https://www.acmicpc.net/problem/15486
- **난이도**: 골드5

## 풀이 방법

간단히 어떤 방식으로 풀었는지 설명해주세요.

```
시간복잡도 O(N*(M/2)) 로 풀었다가 시간초과 발생하여 AI 활용하였습니다.

1. dp[N+2] 로 설정 한 이유는, 7일차에 T가 1이라면, 연산상 8이 되지만 금액을 더해야 하기 때문에 인덱스를 8까지 열어 놓았습니다.

2. i가 일수라 가정하고, 상담을 하지 않는 경우인, dp[i+1] 에 dp[i] 값을 이어주고,
상담을 하는 경우에는, 상담 금액을 얻을 수 있는 날짜를 계산,
endDay = i + T[i] 를 index로 하여, dp[i] + p[i] 을 구합니다.

최종적으로 마지막 N 에서 가장 큰 값이 남게 됩니다.
시간복잡도: O(N)
```

## 체크리스트

- [x] 코드가 정상적으로 실행되나요?
- [x] 커밋 메시지가 컨벤션을 따르나요?
- [x] 파일명이 올바른가요? (`{닉네임}.{확장자}`)

## 추가 코멘트

(선택사항) 추가로 공유하고 싶은 내용이 있다면 작성해주세요.
