### PR TITLE
[Week04] BOJ 1946: 신입사원

### DIFF
--- a/weekly/week04/BOJ_1946_신입사원/sukangpunch.java
+++ b/weekly/week04/BOJ_1946_신입사원/sukangpunch.java
@@ -1,0 +1,70 @@
+package study.week04;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+// 신입사원
+public class BOJ_1946 {
+
+    static class Candidate {
+        int document;
+        int interview;
+        boolean check;
+
+        public Candidate(int document, int interview){
+            this.document = document;
+            this.interview = interview;
+            this.check = true;
+        }
+
+        public static final Comparator<Candidate> BY_DOCUMENT =
+                Comparator.comparingInt(c -> c.document);
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int T = Integer.parseInt(br.readLine());
+
+        for(int t=0; t<T; t++){
+            int N = Integer.parseInt(br.readLine());
+            List<Candidate> candidates = new ArrayList<>();
+
+            for(int i=0; i<N; i++){
+                String []s = br.readLine().split(" ");
+                int score1 = Integer.parseInt(s[0]);
+                int score2 = Integer.parseInt(s[1]);
+                candidates.add(new Candidate(score1, score2));
+            }
+
+            candidates.sort(Candidate.BY_DOCUMENT);
+            int bestInterview = candidates.get(0).interview;
+
+            for(int i=1; i<N; i++){
+                Candidate candidate = candidates.get(i);
+                if(candidate.interview < bestInterview){
+                    bestInterview = candidate.interview;
+                }else{
+                    candidate.check = false;
+                }
+            }
+
+            int cnt = 0;
+            for(int i=0; i<N; i++){
+                Candidate candidate = candidates.get(i);
+                if(candidate.check){
+                    cnt++;
+                }
+            }
+
+            sb.append(cnt).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 문제 정보

- **플랫폼**: 백준
- **문제 번호**: 1946
- **문제 이름**: 신입사원
- **문제 링크**: https://www.acmicpc.net/problem/1946
- **난이도**: 실버 1

## 풀이 방법

간단히 어떤 방식으로 풀었는지 설명해주세요.

```
시간복잡도  :O(NlogN)
문제에서 제시하는 기준은, 서류 및 면접 성적 모두 특정 지원자보다 낮은 지원자는 탈락
서류 기반으로 정렬을 한 다음, 면접 성적을 비교 한다면, 자신보다 높은 서류 성적의 지원자와의 면접 성적만 비교하여 탈락 여부를 확인할 수 있다.
여기서 자신보다 높은 서류 성적의 모든 지원자를 비교할 필요 없이, 자신보다 높은 서류 성적 지원자 중 최고등수와 비교하면 되어 정렬의 시간복잡도인 O(NlogN) 으로 처리할 수 있다.
```

## 체크리스트

- [x] 코드가 정상적으로 실행되나요?
- [x] 커밋 메시지가 컨벤션을 따르나요?
- [x] 파일명이 올바른가요? (`{닉네임}.{확장자}`)

## 추가 코멘트

(선택사항) 추가로 공유하고 싶은 내용이 있다면 작성해주세요.
