### PR TITLE
[Week05] BOJ 14002: 가장 긴 증가하는 부분 수열4

### DIFF
--- a/weekly/week05/BOJ_14002_가장긴증가하는부분수열4/sukangpunch.java
+++ b/weekly/week05/BOJ_14002_가장긴증가하는부분수열4/sukangpunch.java
@@ -1,0 +1,74 @@
+package study.week05;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Stack;
+
+// 가장 긴 증가하는 부분 수열4
+public class BOJ_14002 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(br.readLine());
+
+        int [] arr = new int[N];
+        String []s = br.readLine().split(" ");
+
+        for(int i=0; i<N; i++){
+            arr[i] = Integer.parseInt(s[i]);
+        }
+
+        int [] dp = new int[N];
+        int [] pre = new int[N];
+        Arrays.fill(dp, 1);
+        pre[0] = 0;
+
+        for(int i=1; i<N; i++){
+            for(int j=0; j < i; j++){
+                if(arr[i] > arr[j]){
+                    if(dp[i] < dp[j] + 1){
+                        dp[i] = dp[j] + 1;
+                        pre[i] = j;
+                    }
+                }else{
+                    if(dp[i] <= 1) {
+                        dp[i] = 1;
+                        pre[i] = i;
+                    }
+                }
+            }
+        }
+
+        int max = 0;
+        int maxIdx = 0;
+        for(int i=0; i<N; i++){
+            if(max < dp[i]){
+                max = dp[i];
+                maxIdx = i;
+            }
+        }
+
+        // 최대 부분수열 길이
+        sb.append(max).append("\n");
+
+        Stack<Integer> st = new Stack<>();
+        st.push(arr[maxIdx]);
+        int tmp = maxIdx;
+
+        while(true){
+            if(tmp == pre[tmp])break;
+            tmp = pre[tmp];
+            st.push(arr[tmp]);
+        }
+
+        while(!st.isEmpty()){
+            sb.append(st.pop()).append(" ");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 문제 정보

- **플랫폼**: 백준
- **문제 번호**: 14002
- **문제 이름**: 가장 긴 증가하는 부분 수열4
- **문제 링크**: https://www.acmicpc.net/problem/14002
- **난이도**: 골드4

## 풀이 방법

간단히 어떤 방식으로 풀었는지 설명해주세요.

```
알고리즘: dp
시간복잡도: O(N^2)
질문게시판 확인
dp 를 활용하여 이중 포문(i~N, j~i) 을 통해서 현재 i에 대하여 이전 값들 이 수열을 이룰 수 있으면 dp 를 업데이트, 할 수 없으면 dp 값을 초기화
또한, 경로 탐색을 해야 하므로 pre 배열을 두었는데 값이 업데이트 될 때, 이전 j 값을 i인덱스에 저장하면 된다.
그리고 수열을 이룰 수 없을 때, dp 값을 확인하여 1보다 크다면, 이미 수열을 이루고 있는 상황이므로 넘어가고, 1보다 같거나 작으면 수열을 이루지 않는 상황이므로 pre 값을 자기 자신으로 두고 이를 반복 
```

## 체크리스트

- [x] 코드가 정상적으로 실행되나요?
- [x] 커밋 메시지가 컨벤션을 따르나요?
- [x] 파일명이 올바른가요? (`{닉네임}.{확장자}`)

## 추가 코멘트

(선택사항) 추가로 공유하고 싶은 내용이 있다면 작성해주세요.
