### PR TITLE
[Week05] BOJ 1781: 컵라면

### DIFF
--- a/weekly/week05/BOJ_1781_컵라면/sukangpunch.java
+++ b/weekly/week05/BOJ_1781_컵라면/sukangpunch.java
@@ -1,0 +1,70 @@
+package study.week05;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+
+// 컵라면
+public class BOJ_1781 {
+
+    static class Problem implements Comparable<Problem> {
+
+        int deadLine;
+        int cup;
+
+        public Problem(int deadLine, int cup) {
+            this.deadLine = deadLine;
+            this.cup = cup;
+        }
+
+        @Override
+        public int compareTo(Problem o) {
+            if (this.deadLine == o.deadLine) {
+                return o.cup - this.cup;
+            }
+            return this.deadLine - o.deadLine;
+        }
+    }
+
+    static PriorityQueue<Problem> pq;
+    static int N;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        pq = new PriorityQueue<>();
+
+        for (int i = 0; i < N; i++) {
+            String[] s = br.readLine().split(" ");
+            int deadLine = Integer.parseInt(s[0]);
+            int cup = Integer.parseInt(s[1]);
+            pq.add(new Problem(deadLine, cup));
+        }
+
+        PriorityQueue<Integer> select = new PriorityQueue<>();
+
+        while(!pq.isEmpty()){
+            Problem problem = pq.poll();
+            int deadLine = problem.deadLine;
+            int cup = problem.cup;
+
+            if(select.size() < deadLine){
+                select.offer(cup);
+            }else{
+                if(!select.isEmpty() && select.peek() < cup){ // 만약 선택한 문제 중 가장 적은 컵라면보다 현재 추가하려는 problem 의 컵라면 개수가 더 많다면
+                    select.poll();
+                    select.offer(cup);
+                }
+            }
+        }
+
+        long result = 0;
+        for(int cup : select){
+            result += cup;
+        }
+
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 문제 정보

- **플랫폼**: 백준
- **문제 번호**: 1781
- **문제 이름**: 컵라면
- **문제 링크**: https://www.acmicpc.net/problem/1781
- **난이도**: 골드2

## 풀이 방법

간단히 어떤 방식으로 풀었는지 설명해주세요.

```
예시:
- 알고리즘 : 그리디, 우선순위 큐
- 시간복잡도: O(NlogN)
- 답확인 : O
그리디임은 눈치챘지만 구현에 있어서 막혔다.
현재 카운팅된 일수가 1이어도 데드라인이 1인 문제보다 3인 더 많은 컵라면을 주는 문제를 선택할 수도 있는 경우를 고려하지 못했다.
이를 구현하기 위해, 문제 선택 우선순위 큐를 하나 더 두어서, 데드라인, 라면 수로 정렬을 한다. 선택 큐의 사이즈가 현재 일수를 나타낼 수 있으므로,  
1. 문제 큐에서 빼낸 문제의 데드라인보다 선택 큐의 사이즈가 작다면, 바로 선택큐에 추가
2. 문제 큐에서 빼낸 문제의 데드라인보다 선택 큐의 사이즈가 크다면, 오름차순으로 정렬된 선택 큐에서 가장 작은 값과, 문제 큐의 값을 비교해서 문제 큐의 값이 더 크다면 해당 문제를 빼고, 문제 큐의 문제를 넣는다.
```

## 체크리스트

- [X] 코드가 정상적으로 실행되나요?
- [X] 커밋 메시지가 컨벤션을 따르나요?
- [X] 파일명이 올바른가요? (`{닉네임}.{확장자}`)

## 추가 코멘트

(선택사항) 추가로 공유하고 싶은 내용이 있다면 작성해주세요.
