### PR TITLE
[Week09] BOJ 23088: Aging

### DIFF
--- a/weekly/week09/BOJ_23088_Aging/whqtker.cpp
+++ b/weekly/week09/BOJ_23088_Aging/whqtker.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <tuple>
+#include <queue>
+#include <vector>
+
+using namespace std;
+typedef tuple<int,int,int> tii;
+
+int main() {
+    cin.tie(0);
+    ios::sync_with_stdio(0);
+
+    int n;
+    cin>>n;
+
+    // 실행 순위: 우선순위 높음 > 실행 시간 짧음 > 먼저 등장
+    vector<tii> v; // 실행 요청 시점, 초기 우선순위, 실행 시간
+    for (int i=0;i<n;i++) {
+        int a,b,c; // 실행 요청 시점, 초기 우선순위, 실행 시간
+        cin>>a>>b>>c;
+        v.push_back({a,b,c});
+    }
+
+    int curTime=0;
+    int idx=0;
+    priority_queue<tii> pq; // 보정된 우선순위, -실행시간, -등장 번호
+    while (idx<n||!pq.empty()) {
+        // 현재 시간까지 도착한 작업 pq에 삽입
+        while (idx<n&&get<0>(v[idx])<=curTime) {
+            pq.push({get<1>(v[idx])-get<0>(v[idx]),-get<2>(v[idx]),-(idx+1)});
+            idx++;
+        }
+
+        // 처리할 작업 없는 경우
+        if (pq.empty()) {
+            curTime=get<0>(v[idx]);
+        }
+        else {
+            int num=-get<2>(pq.top());
+            cout<<num<<" ";
+            curTime-=get<1>(pq.top());
+            pq.pop();
+        }
+    }
+}


### PR DESCRIPTION
## 문제 정보

- **플랫폼**: 백준
- **문제 번호**: 23088
- **문제 이름**: Aging
- **문제 링크**: https://www.acmicpc.net/problem/23088
- **난이도**: Gold 2

## 풀이 방법

간단히 어떤 방식으로 풀었는지 설명해주세요.

프로세스들을 우선순위 큐에 넣되, aging을 일일히 구현하면 시간 초과가 발생한다.

우선순위를 $P$, 실행 요청 시각을 $R$이라고 할 때, 특정 시각 $T$에서 $i$번째 프로세스의 우선순위는 $P_i+(T-R_i)$이다. $T$는 모든 프로세스에게 동일하게 더해지므로, 우선순위 큐의 상대적 순서는 $P$와 $R$만 고려해도 무방하다. 즉, 우선순위 큐에 프로세스를 삽입할 때, $P_i$가 아니라 aging을 고려한 우선순위인 $P_i-R_i$을 넣게 되면, aging을 위해 매번 `pop` 및 `push` 연산을 수행하지 않아도 된다.

## 체크리스트

- [ ] 코드가 정상적으로 실행되나요?
- [ ] 커밋 메시지가 컨벤션을 따르나요?
- [ ] 파일명이 올바른가요? (`{닉네임}.{확장자}`)

## 추가 코멘트

(선택사항) 추가로 공유하고 싶은 내용이 있다면 작성해주세요.
